### PR TITLE
change solidId on IssueTrackerPerson to nodeKind IRI

### DIFF
--- a/shapes/person.ttl
+++ b/shapes/person.ttl
@@ -123,7 +123,7 @@ person_shape:IssueTrackerPersonShape
     sh:property [
         sh:path owl:sameAs ;
         sh:maxCount 1 ;
-        sh:class vcard:Individual ;
+        sh:nodeKind sh:IRI ;
         sh:name "Solid ID" ;
         sh:description "The Solid WebID of the person, if available.";
         sh:codeIdentifier "solidId";


### PR DESCRIPTION
## Type of Change

```
* [ ] New domain file
* [ x] Update existing domain file
* [ ] Documentation only
```

If updating:

```
* [ ] New shape
* [ ] Additional constraints (non-breaking)
* [ x] New version of existing shape
```

---

## Domain

```
Domain file: person

```

---

## Shape Details

```
Shape name(s):

IssueTrackerPerson 



Files changed:
person.ttl
```

---

## Shape Change

```
* [ ] New shape
* [x] New version of existing shape
* [ ] Non-breaking constraint addition
* [ ] Documentation update
```

Description:

replaced sh:class vcard:Individual with sh:nodeKind sh:IRI - this constraint was not present in source doc - just that it should be a named node URI 
```
 [ a :NamedNodeURIField; ui:label "Solid ID"; ui:property owl:sameAs; ui:size 60 ]
```
---

## Immutability Confirmation

```
* [x ] Existing constraints were not modified
* [x] Previously valid data remains valid
* [x] If behaviour changed, a new shape/version was introduced
```

---



---

## Reviewer Checklist

```
* [ ] Immutability respected
* [ ] Targeting is correct
* [ ] Constraints justified
* [ ] Examples match expected behaviour
```

