### PR TITLE
Add Annotation/Note shape (W3C Web Annotation Vocabulary)

### DIFF
--- a/shapes/annotation.ttl
+++ b/shapes/annotation.ttl
@@ -33,12 +33,16 @@ annotation_shape:AnnotationShape
     ] ;
 
     # Inline textual body (for simple comment / note cases).
+    # Per the Web Annotation Data Model (§3.2.4), an annotation SHOULD NOT
+    # have both oa:bodyValue and oa:hasBody. This shape does not enforce
+    # the exclusion (favouring interoperability) but consumers SHOULD
+    # populate only one of the two.
     sh:property [
         sh:path oa:bodyValue ;
         sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:name "Body Value" ;
-        sh:description "Textual content of the annotation body, used for plain-text comments or notes (Web Annotation Vocabulary, oa:bodyValue)." ;
+        sh:description "Textual content of the annotation body, used for plain-text comments or notes (Web Annotation Vocabulary, oa:bodyValue). SHOULD NOT be combined with oa:hasBody on the same annotation." ;
         sh:codeIdentifier "bodyValue";
     ] ;
 
@@ -47,7 +51,7 @@ annotation_shape:AnnotationShape
         sh:path oa:hasBody ;
         sh:nodeKind sh:BlankNodeOrIRI ;
         sh:name "Body" ;
-        sh:description "A resource that provides the content of the annotation (Web Annotation Vocabulary, oa:hasBody). May be repeated when an annotation has multiple bodies." ;
+        sh:description "A resource that provides the content of the annotation (Web Annotation Vocabulary, oa:hasBody). May be repeated when an annotation has multiple bodies. SHOULD NOT be combined with oa:bodyValue on the same annotation." ;
         sh:codeIdentifier "hasBody";
     ] ;
 
@@ -76,13 +80,13 @@ annotation_shape:AnnotationShape
 
     # Creator. Permits a WebID IRI or an embedded agent description, matching
     # the Web Annotation Data Model which allows the creator to be referenced
-    # or described inline.
+    # or described inline. Cardinality is left open as the data model permits
+    # multiple creators (co-creation).
     sh:property [
         sh:path dct:creator ;
         sh:nodeKind sh:BlankNodeOrIRI ;
-        sh:maxCount 1 ;
         sh:name "Creator" ;
-        sh:description "The agent that created the annotation. Typically a WebID IRI in Solid, but the Web Annotation Data Model also permits an embedded agent description." ;
+        sh:description "The agent that created the annotation. Typically a WebID IRI in Solid, but the Web Annotation Data Model also permits an embedded agent description and multiple creators." ;
         sh:codeIdentifier "creator";
     ] ;
 

--- a/shapes/annotation.ttl
+++ b/shapes/annotation.ttl
@@ -1,0 +1,106 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix annotation_shape: <https://solidproject.org/shapes/annotation#> .
+
+annotation_shape:AnnotationShape
+    a sh:NodeShape ;
+    sh:targetClass oa:Annotation ;
+    sh:name "Annotation Shape" ;
+    sh:description "SHACL shape describing a Web Annotation covering common note, bookmark, comment, and highlight cases." ;
+    dct:created "2026-04-23"^^xsd:date ;
+    vs:term_status "testing" ;
+    dc:source <https://www.w3.org/TR/annotation-vocab/> ;
+    prov:wasDerivedFrom <https://www.w3.org/TR/annotation-vocab/> ;
+    dct:references <http://www.w3.org/ns/oa#Annotation> ; # references the oa:Annotation class from the W3C Web Annotation Vocabulary, which is the expected type of an annotation node, together with the oa:hasBody, oa:hasTarget, oa:bodyValue, and oa:motivatedBy properties used to relate an annotation to its body, target, textual body content, and motivation respectively.
+    dct:references <https://www.w3.org/TR/annotation-model/> ; # references the W3C Web Annotation Data Model recommendation which defines the conceptual model used by the Web Annotation Vocabulary.
+    sh:codeIdentifier "Annotation";
+
+    # Type: an annotation should be typed as oa:Annotation.
+    sh:property [
+        sh:path rdf:type ;
+        sh:hasValue oa:Annotation ;
+        sh:name "Type" ;
+        sh:description "The RDF type of the annotation, which must include oa:Annotation." ;
+        sh:codeIdentifier "type";
+    ] ;
+
+    # Inline textual body (for simple comment / note cases).
+    sh:property [
+        sh:path oa:bodyValue ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Body Value" ;
+        sh:description "Textual content of the annotation body, used for plain-text comments or notes (Web Annotation Vocabulary, oa:bodyValue)." ;
+        sh:codeIdentifier "bodyValue";
+    ] ;
+
+    # External or embedded body resource(s) (for richer body cases).
+    sh:property [
+        sh:path oa:hasBody ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:name "Body" ;
+        sh:description "A resource that provides the content of the annotation (Web Annotation Vocabulary, oa:hasBody). May be repeated when an annotation has multiple bodies." ;
+        sh:codeIdentifier "hasBody";
+    ] ;
+
+    # Target(s) the annotation is about. Required for an annotation to be meaningful.
+    sh:property [
+        sh:path oa:hasTarget ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:minCount 1 ;
+        sh:name "Target" ;
+        sh:description "The resource (or specific resource) that the annotation is about (Web Annotation Vocabulary, oa:hasTarget)." ;
+        sh:codeIdentifier "hasTarget";
+    ] ;
+
+    # Motivation. Constrained to the common note / bookmark / highlight / comment values.
+    sh:property [
+        sh:path oa:motivatedBy ;
+        sh:nodeKind sh:IRI ;
+        sh:in (
+            oa:bookmarking
+            oa:commenting
+            oa:highlighting
+        ) ;
+        sh:name "Motivation" ;
+        sh:description "Why the annotation was created. Limited here to the common note-taking subset: bookmarking, commenting, and highlighting (Web Annotation Vocabulary, oa:Motivation)." ;
+        sh:codeIdentifier "motivatedBy";
+    ] ;
+
+    # Creator (typically a WebID for Solid use).
+    sh:property [
+        sh:path dct:creator ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:name "Creator" ;
+        sh:description "The agent that created the annotation, typically referenced as a WebID." ;
+        sh:codeIdentifier "creator";
+    ] ;
+
+    # Created date.
+    sh:property [
+        sh:path dct:created ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Created" ;
+        sh:description "The date and time at which the annotation was created." ;
+        sh:codeIdentifier "created";
+    ] ;
+
+    # Last modified date.
+    sh:property [
+        sh:path dct:modified ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Modified" ;
+        sh:description "The date and time at which the annotation was last modified." ;
+        sh:codeIdentifier "modified";
+    ] .

--- a/shapes/annotation.ttl
+++ b/shapes/annotation.ttl
@@ -61,27 +61,28 @@ annotation_shape:AnnotationShape
         sh:codeIdentifier "hasTarget";
     ] ;
 
-    # Motivation. Constrained to the common note / bookmark / highlight / comment values.
+    # Motivation. Left open to the full Web Annotation motivation set so that
+    # the shape does not reject conforming annotations using motivations
+    # outside the common note-taking subset (e.g., oa:tagging, oa:replying).
+    # Apps focused on notes/bookmarks/highlights typically use oa:bookmarking,
+    # oa:commenting, or oa:highlighting.
     sh:property [
         sh:path oa:motivatedBy ;
         sh:nodeKind sh:IRI ;
-        sh:in (
-            oa:bookmarking
-            oa:commenting
-            oa:highlighting
-        ) ;
         sh:name "Motivation" ;
-        sh:description "Why the annotation was created. Limited here to the common note-taking subset: bookmarking, commenting, and highlighting (Web Annotation Vocabulary, oa:Motivation)." ;
+        sh:description "Why the annotation was created (Web Annotation Vocabulary, oa:Motivation). Common note-taking values are oa:bookmarking, oa:commenting, and oa:highlighting." ;
         sh:codeIdentifier "motivatedBy";
     ] ;
 
-    # Creator (typically a WebID for Solid use).
+    # Creator. Permits a WebID IRI or an embedded agent description, matching
+    # the Web Annotation Data Model which allows the creator to be referenced
+    # or described inline.
     sh:property [
         sh:path dct:creator ;
-        sh:nodeKind sh:IRI ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
         sh:maxCount 1 ;
         sh:name "Creator" ;
-        sh:description "The agent that created the annotation, typically referenced as a WebID." ;
+        sh:description "The agent that created the annotation. Typically a WebID IRI in Solid, but the Web Annotation Data Model also permits an embedded agent description." ;
         sh:codeIdentifier "creator";
     ] ;
 


### PR DESCRIPTION
## Type of Change

```
* [x] New domain file
* [ ] Update existing domain file
* [ ] Documentation only
```

---

## Domain

```
Domain file:        shapes/annotation.ttl
Purpose of domain:  Validation shape for Web Annotations covering the
                    common note, bookmark, comment, and highlight cases.
Intended use cases: Note-taking apps, bookmarking apps, and
                    annotation/highlight apps that store user-generated
                    content in a Solid Pod.
```

---

## Shape Details

```
Shape name(s):      annotation_shape:AnnotationShape
Target class/node:  oa:Annotation
Files changed:      shapes/annotation.ttl (new)
```

---

## Shape Change

```
* [x] New shape
* [ ] New version of existing shape
* [ ] Non-breaking constraint addition
* [ ] Documentation update
```

Description:

Adds a SHACL shape for `oa:Annotation` grounded in the W3C
[Web Annotation Vocabulary](https://www.w3.org/TR/annotation-vocab/)
(Recommendation, 2017) and the
[Web Annotation Data Model](https://www.w3.org/TR/annotation-model/).

Constraints cover:

- `rdf:type` (must include `oa:Annotation`)
- `oa:bodyValue` (`xsd:string`, max 1) for inline textual bodies
- `oa:hasBody` (IRI or blank node) for embedded or referenced bodies
- `oa:hasTarget` (IRI or blank node, min 1)
- `oa:motivatedBy` (IRI) – kept open per the Web Annotation Vocabulary
  motivation set; descriptions cite the common note-taking values
  (`oa:bookmarking`, `oa:commenting`, `oa:highlighting`).
- `dct:creator` (IRI or blank node) – permits a WebID or an inline
  agent description; cardinality left open to allow co-creation
- `dct:created`, `dct:modified` (`xsd:dateTime`, max 1 each)

Mutual exclusion of `oa:bodyValue` and `oa:hasBody` (Data Model
§3.2.4 SHOULD NOT) is documented in the property descriptions but not
enforced, in line with the catalogue's "Interoperability First"
design principle.

---

## Immutability Confirmation

```
* [x] Existing constraints were not modified
* [x] Previously valid data remains valid
* [x] If behaviour changed, a new shape/version was introduced
```

(New file – no existing shapes were touched.)

---

## Examples

### Valid example

```turtle
@prefix oa:  <http://www.w3.org/ns/oa#> .
@prefix dct: <http://purl.org/dc/terms/> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

</annotations/note-1>
    a oa:Annotation ;
    oa:bodyValue "Reminder: read the W3C Web Annotation Recommendation." ;
    oa:hasTarget <https://www.w3.org/TR/annotation-vocab/> ;
    oa:motivatedBy oa:commenting ;
    dct:creator <https://example.org/profile/card#me> ;
    dct:created "2026-04-23T14:00:00Z"^^xsd:dateTime .
```

### Invalid example

```turtle
@prefix oa:  <http://www.w3.org/ns/oa#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

</annotations/note-2>
    a oa:Annotation ;
    # Missing oa:hasTarget – required by the shape (min 1).
    oa:bodyValue "An annotation with no target." .
```

---

## Compatibility

```
* [x] Fully backwards compatible
* [ ] May cause new validation failures
* [ ] Breaking change
```

New domain file. No existing shape touched.

---

## Validation

```
* [x] SHACL validation run
* [x] Example data tested
```

Tools used: `pyshacl`, plus the repository's `scripts/validate-shacl-shapes-file.py`, `scripts/check-metadata-and-immutability-file.py`, and `scripts/check-namespaces-and-names-file.py`.

---

## Reviewer Checklist

```
* [ ] Immutability respected
* [ ] Targeting is correct
* [ ] Constraints justified
* [ ] Examples match expected behaviour
```