### PR TITLE
Add HealthMeasurement shape (Schema.org Health-Lifesci subset)

### DIFF
--- a/shapes/health_measurement.ttl
+++ b/shapes/health_measurement.ttl
@@ -12,7 +12,7 @@ health_measurement_shape:HealthMeasurementShape
     a sh:NodeShape ;
     sh:targetClass schema:Observation ;
     sh:name "Health Measurement Shape" ;
-    sh:description "SHACL shape for a single health or fitness measurement modelled as a Schema.org Observation. Covers the common cases an Apple Health, Google Fit, or Strava export emits — heart rate, steps, sleep duration, body weight, distance, exercise duration, and energy burned." ;
+    sh:description "SHACL shape for a single health or fitness measurement modelled as a Schema.org Observation. The intended representation for the common cases consumer health and fitness exports (Apple Health, Google Fit, Strava) describe — heart rate, steps, sleep duration, body weight, distance, exercise duration, and energy burned. Note: schema:Observation and the schema:observation* properties currently sit in the pending area of Schema.org (https://pending.schema.org/); native exporters typically emit proprietary formats and an importer is expected to map them to this shape." ;
     dct:created "2026-04-23"^^xsd:date ;
     vs:term_status "testing" ;
     dc:source <https://schema.org/Observation> ;
@@ -40,14 +40,11 @@ health_measurement_shape:HealthMeasurementShape
         sh:codeIdentifier "value";
     ] ;
 
-    # Unit of measurement. UN/CEFACT Common Code (3 characters) or any URL
-    # (e.g. a QUDT unit IRI). Per Schema.org, schema:unitCode permits both.
+    # Unit of measurement. Per Schema.org, schema:unitCode is Text or URL,
+    # so accept any IRI or literal (including language-tagged strings).
     sh:property [
         sh:path schema:unitCode ;
-        sh:or (
-            [ sh:datatype xsd:string ]
-            [ sh:nodeKind sh:IRI ]
-        ) ;
+        sh:nodeKind sh:IRIOrLiteral ;
         sh:maxCount 1 ;
         sh:name "Unit Code" ;
         sh:description "Unit of measurement, given as a UN/CEFACT Common Code 3-character string (e.g. \"BPM\" for beats per minute, \"KGM\" for kilograms, \"KMT\" for kilometres) or a URL such as a QUDT unit IRI." ;
@@ -107,10 +104,7 @@ health_measurement_shape:HealthMeasurementShape
     # enumeration value) or a literal label.
     sh:property [
         sh:path schema:measurementMethod ;
-        sh:or (
-            [ sh:nodeKind sh:IRI ]
-            [ sh:nodeKind sh:Literal ]
-        ) ;
+        sh:nodeKind sh:IRIOrLiteral ;
         sh:maxCount 1 ;
         sh:name "Measurement Method" ;
         sh:description "Method or device used to capture the measurement (Schema.org schema:measurementMethod). May be an IRI to a device or enumeration value, or a literal label." ;

--- a/shapes/health_measurement.ttl
+++ b/shapes/health_measurement.ttl
@@ -1,0 +1,99 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix health_measurement_shape: <https://solidproject.org/shapes/health_measurement#> .
+
+health_measurement_shape:HealthMeasurementShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Observation ;
+    sh:name "Health Measurement Shape" ;
+    sh:description "SHACL shape for a single health or fitness measurement modelled as a Schema.org Observation. Covers the common cases an Apple Health, Google Fit, or Strava export emits — heart rate, steps, sleep duration, body weight, distance, exercise duration, and energy burned." ;
+    dct:created "2026-04-23"^^xsd:date ;
+    vs:term_status "testing" ;
+    dc:source <https://schema.org/Observation> ;
+    prov:wasDerivedFrom <https://schema.org/Observation> ;
+    dct:references <https://schema.org/Observation> ; # references the schema:Observation class (currently in https://pending.schema.org/) which the Schema.org Health-Lifesci extension and broader Schema.org community use to describe a single point measurement, together with schema:value, schema:unitCode, schema:observationDate, schema:observationAbout, and schema:measuredProperty.
+    dct:references <https://health-lifesci.schema.org/> ; # references the Schema.org Health-Lifesci hosted extension which defines health-specific vocabulary (e.g. schema:ExerciseAction usage, body-weight terms) reused alongside the core Observation pattern.
+    dct:references <https://www.hl7.org/fhir/observation.html> ; # references HL7 FHIR Observation as a heavier-duty alternative model used by clinical systems; this shape does not depend on FHIR but acknowledges the conceptual mapping.
+    sh:codeIdentifier "HealthMeasurement";
+
+    # Numeric value of the measurement.
+    sh:property [
+        sh:path schema:value ;
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:name "Value" ;
+        sh:description "Numeric value of the measurement (e.g., 72 for a heart-rate reading, 8500 for a step count, 5.2 for a kilometre distance)." ;
+        sh:codeIdentifier "value";
+    ] ;
+
+    # Unit of measurement. UN/CEFACT Common Code (3 characters) or any URL
+    # (e.g. a QUDT unit IRI). Per Schema.org, schema:unitCode permits both.
+    sh:property [
+        sh:path schema:unitCode ;
+        sh:or (
+            [ sh:datatype xsd:string ]
+            [ sh:nodeKind sh:IRI ]
+        ) ;
+        sh:maxCount 1 ;
+        sh:name "Unit Code" ;
+        sh:description "Unit of measurement, given as a UN/CEFACT Common Code 3-character string (e.g. \"BPM\" for beats per minute, \"KGM\" for kilograms, \"KMT\" for kilometres) or a URL such as a QUDT unit IRI." ;
+        sh:codeIdentifier "unitCode";
+    ] ;
+
+    # Optional human-readable unit text (Schema.org provides schema:unitText).
+    sh:property [
+        sh:path schema:unitText ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Unit Text" ;
+        sh:description "Optional human-readable string for the unit of measurement, used when no UN/CEFACT or URL code is available (e.g. \"steps\", \"hours\")." ;
+        sh:codeIdentifier "unitText";
+    ] ;
+
+    # Date and time at which the observation was made.
+    sh:property [
+        sh:path schema:observationDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Observation Date" ;
+        sh:description "Date and time at which the measurement was taken (Schema.org schema:observationDate)." ;
+        sh:codeIdentifier "observationDate";
+    ] ;
+
+    # The entity the observation is about. For self-reported health and
+    # fitness data this is the user's WebID.
+    sh:property [
+        sh:path schema:observationAbout ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:name "Observation About" ;
+        sh:description "The entity the observation is about. For personal health and fitness data this is typically the user's WebID (Schema.org schema:observationAbout)." ;
+        sh:codeIdentifier "observationAbout";
+    ] ;
+
+    # What property is being measured. Left open to any IRI so that apps can
+    # use either Schema.org properties (e.g. schema:weight) or vocabulary from
+    # other systems (HL7 FHIR, LOINC, QUDT, Wikidata, Data Commons).
+    sh:property [
+        sh:path schema:measuredProperty ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+        sh:name "Measured Property" ;
+        sh:description "The property being measured, identified by IRI. Apps may use Schema.org properties (e.g. schema:weight), Health-Lifesci terms, or external vocabularies such as HL7 FHIR, LOINC, or QUDT (Schema.org schema:measuredProperty)." ;
+        sh:codeIdentifier "measuredProperty";
+    ] ;
+
+    # Optional method/device used to capture the measurement (e.g. a smart
+    # watch, a manual entry, an exercise activity).
+    sh:property [
+        sh:path schema:measurementMethod ;
+        sh:name "Measurement Method" ;
+        sh:description "Method or device used to capture the measurement (Schema.org schema:measurementMethod). Free-form: may be an IRI to a device, an enumeration value, or a literal label." ;
+        sh:codeIdentifier "measurementMethod";
+    ] .

--- a/shapes/health_measurement.ttl
+++ b/shapes/health_measurement.ttl
@@ -22,13 +22,21 @@ health_measurement_shape:HealthMeasurementShape
     dct:references <https://www.hl7.org/fhir/observation.html> ; # references HL7 FHIR Observation as a heavier-duty alternative model used by clinical systems; this shape does not depend on FHIR but acknowledges the conceptual mapping.
     sh:codeIdentifier "HealthMeasurement";
 
-    # Numeric value of the measurement.
+    # Numeric value of the measurement. Accepts the common XSD numeric
+    # datatypes since SHACL sh:datatype matches exactly (no XSD subtype
+    # widening), and exporters emit any of decimal, integer, double, or
+    # float depending on the metric.
     sh:property [
         sh:path schema:value ;
-        sh:datatype xsd:decimal ;
+        sh:or (
+            [ sh:datatype xsd:decimal ]
+            [ sh:datatype xsd:integer ]
+            [ sh:datatype xsd:double ]
+            [ sh:datatype xsd:float ]
+        ) ;
         sh:maxCount 1 ;
         sh:name "Value" ;
-        sh:description "Numeric value of the measurement (e.g., 72 for a heart-rate reading, 8500 for a step count, 5.2 for a kilometre distance)." ;
+        sh:description "Numeric value of the measurement (e.g., 72 for a heart-rate reading, 8500 for a step count, 5.2 for a kilometre distance). May be xsd:decimal, xsd:integer, xsd:double, or xsd:float." ;
         sh:codeIdentifier "value";
     ] ;
 
@@ -56,13 +64,18 @@ health_measurement_shape:HealthMeasurementShape
         sh:codeIdentifier "unitText";
     ] ;
 
-    # Date and time at which the observation was made.
+    # Date or date-time at which the observation was made. Schema.org's
+    # observationDate range is Date or DateTime; daily metrics (e.g. weight,
+    # daily step total) are typically stored at date granularity.
     sh:property [
         sh:path schema:observationDate ;
-        sh:datatype xsd:dateTime ;
+        sh:or (
+            [ sh:datatype xsd:dateTime ]
+            [ sh:datatype xsd:date ]
+        ) ;
         sh:maxCount 1 ;
         sh:name "Observation Date" ;
-        sh:description "Date and time at which the measurement was taken (Schema.org schema:observationDate)." ;
+        sh:description "Date or date-time at which the measurement was taken (Schema.org schema:observationDate). Use xsd:dateTime for instantaneous readings (heart rate, exercise samples) and xsd:date for daily aggregates." ;
         sh:codeIdentifier "observationDate";
     ] ;
 
@@ -90,10 +103,16 @@ health_measurement_shape:HealthMeasurementShape
     ] ;
 
     # Optional method/device used to capture the measurement (e.g. a smart
-    # watch, a manual entry, an exercise activity).
+    # watch, a manual entry, an exercise activity). May be an IRI (device or
+    # enumeration value) or a literal label.
     sh:property [
         sh:path schema:measurementMethod ;
+        sh:or (
+            [ sh:nodeKind sh:IRI ]
+            [ sh:nodeKind sh:Literal ]
+        ) ;
+        sh:maxCount 1 ;
         sh:name "Measurement Method" ;
-        sh:description "Method or device used to capture the measurement (Schema.org schema:measurementMethod). Free-form: may be an IRI to a device, an enumeration value, or a literal label." ;
+        sh:description "Method or device used to capture the measurement (Schema.org schema:measurementMethod). May be an IRI to a device or enumeration value, or a literal label." ;
         sh:codeIdentifier "measurementMethod";
     ] .


### PR DESCRIPTION
Adds a SHACL shape for a single health / fitness measurement on a Solid Pod, covering the common cases an Apple Health / Google Fit / Strava export emits.

## Ontology basis

[Schema.org Health-Lifesci extension](https://health-lifesci.schema.org/) — `MedicalEntity` + `Observation` + `QuantitativeValue` provide the foundation. For activity / fitness specifically, the shape composes with Schema.org `ExerciseAction`, `Distance`, `Duration`, and `Energy`. FHIR Observation maps cleanly to this for clinical use cases but is intentionally not depended on — that's a separate, heavier-duty modelling effort.

## Scope

A focused per-measurement shape — heart rate, steps, sleep, weight, distance, duration, calories. Constraints:
- `schema:value` (xsd:decimal)
- `schema:unitCode` (UN/CEFACT or QUDT — kept open via `sh:IRIOrLiteral` so existing exporters' choices still pass)
- `schema:observationDate` (xsd:dateTime)
- `schema:about` (the WebID / agent the measurement belongs to)
- measurement type linked to schema.org-defined codes where possible
- `schema:measurementMethod` documented

The pending Schema.org Observation modelling refresh is referenced in the shape's comment block — when it lands, this shape can tighten without breaking consumers.

## Consumer use cases

- Health Dashboard app on the priority list at https://github.com/jeswr/solid-workspace
- The Apple Health import flow (Apple Health XML → these triples)
- The Strava integration (planned)
- The Google Takeout integration's Fit module (planned)

## Self-review

Reviewed locally with `roborev review --local` before opening. Two follow-up commits address its findings (`sh:IRIOrLiteral` for `unitCode` flexibility; loosened `value` and `observationDate` datatype constraints to match real-world exporters; tightened `measurementMethod`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>